### PR TITLE
Add neutron driver support floating ip

### DIFF
--- a/senlin/drivers/openstack/neutron_v2.py
+++ b/senlin/drivers/openstack/neutron_v2.py
@@ -223,3 +223,41 @@ class NeutronClient(base.DriverBase):
         self.conn.network.delete_health_monitor(
             hm_id, ignore_missing=ignore_missing)
         return
+
+    @sdk.translate_exception
+    def port_create(self, **attr):
+        res = self.conn.network.create_port(**attr)
+        return res
+
+    @sdk.translate_exception
+    def port_delete(self, port, ignore_missing=True):
+        res = self.conn.network.delete_port(
+            port=port, ignore_missing=ignore_missing)
+        return res
+
+    @sdk.translate_exception
+    def port_update(self, port, **attr):
+        res = self.conn.network.update_port(port, **attr)
+        return res
+
+    @sdk.translate_exception
+    def floatingip_find(self, name_or_id, ignore_missing=False):
+        res = self.conn.network.find_ip(
+            name_or_id, ignore_missing=ignore_missing)
+        return res
+
+    @sdk.translate_exception
+    def floatingip_create(self, **attr):
+        res = self.conn.network.create_ip(**attr)
+        return res
+
+    @sdk.translate_exception
+    def floatingip_delete(self, floating_ip, ignore_missing=True):
+        res = self.conn.network.delete_ip(
+            floating_ip, ignore_missing=ignore_missing)
+        return res
+
+    @sdk.translate_exception
+    def floatingip_update(self, floating_ip, **attr):
+        res = self.conn.network.update_ip(floating_ip, **attr)
+        return res

--- a/senlin/tests/unit/drivers/test_neutron_v2_driver.py
+++ b/senlin/tests/unit/drivers/test_neutron_v2_driver.py
@@ -365,3 +365,45 @@ class TestNeutronV2Driver(base.SenlinTestCase):
         self.nc.healthmonitor_delete(healthmonitor_id)
         self.conn.network.delete_health_monitor.assert_called_with(
             healthmonitor_id, ignore_missing=True)
+
+    def test_port_create(self):
+        port_attr = {
+            'network_id': 'foo'
+        }
+        self.nc.port_create(**port_attr)
+        self.conn.network.create_port.assert_called_once_with(
+            network_id='foo')
+
+    def test_port_delete(self):
+        self.nc.port_delete(port='foo')
+        self.conn.network.delete_port.assert_called_once_with(
+            port='foo', ignore_missing=True)
+
+    def test_port_update(self):
+        attr = {
+            'name': 'new_name'
+        }
+        self.nc.port_update('fake_port', **attr)
+        self.conn.network.update_port.assert_called_once_with(
+            'fake_port', **attr)
+
+    def test_floatingip_create(self):
+        attr = {
+            'network_id': 'foo'
+        }
+        self.nc.floatingip_create(**attr)
+        self.conn.network.create_ip.assert_called_once_with(
+            network_id='foo')
+
+    def test_floatingip_delete(self):
+        self.nc.floatingip_delete(floating_ip='foo')
+        self.conn.network.delete_ip.assert_called_once_with(
+            'foo', ignore_missing=True)
+
+    def test_floatingip_update(self):
+        attr = {
+            'port_id': 'fake_port'
+        }
+        self.nc.floatingip_update('fake_floatingip', **attr)
+        self.conn.network.update_ip.assert_called_once_with(
+            'fake_floatingip', **attr)


### PR DESCRIPTION
Add floatingip_create/update/delete operations to neutron driver.

Change-Id: I4267825fc618acdea527fda15c0730d70bcecad0

Conflicts:
	senlin/drivers/openstack/neutron_v2.py
	senlin/tests/unit/drivers/test_neutron_v2_driver.py