### PR TITLE
Fix cluster-check cannot work problem

### DIFF
--- a/senlin/engine/service.py
+++ b/senlin/engine/service.py
@@ -1379,7 +1379,9 @@ class EngineService(service.Service):
         LOG.info(_LI("Checking Cluster '%(cluster)s'."),
                  {'cluster': identity})
         db_cluster = self.cluster_find(context, identity)
-
+        if not context.user or not context.project:
+            context.user = db_cluster.user
+            context.project = db_cluster.project
         params = {
             'name': 'cluster_check_%s' % db_cluster.id[:8],
             'cause': action_mod.CAUSE_RPC,

--- a/senlin/tests/unit/engine/service/test_clusters.py
+++ b/senlin/tests/unit/engine/service/test_clusters.py
@@ -1653,13 +1653,40 @@ class ClusterTest(base.SenlinTestCase):
     @mock.patch.object(service.EngineService, 'cluster_find')
     @mock.patch.object(dispatcher, 'start_action')
     def test_cluster_check(self, notify, mock_find, mock_action):
-        x_cluster = mock.Mock(id='CID')
+        x_cluster = mock.Mock(id='CID',
+                              user='6820fddbae6742eaa40efb4a51ba50f2',
+                              project='956033b6e9ac4d1999a2f504748b0f73')
         mock_find.return_value = x_cluster
         mock_action.return_value = 'ACTION_ID'
 
         params = {'foo': 'bar'}
         result = self.eng.cluster_check(self.ctx, 'CLUSTER', params)
 
+        self.assertEqual({'action': 'ACTION_ID'}, result)
+        mock_find.assert_called_once_with(self.ctx, 'CLUSTER')
+        mock_action.assert_called_once_with(
+            self.ctx, 'CID', consts.CLUSTER_CHECK,
+            name='cluster_check_CID',
+            cause=am.CAUSE_RPC,
+            status=am.Action.READY,
+            inputs={'foo': 'bar'},
+        )
+        notify.assert_called_once_with()
+
+    @mock.patch.object(am.Action, 'create')
+    @mock.patch.object(service.EngineService, 'cluster_find')
+    @mock.patch.object(dispatcher, 'start_action')
+    def test_cluster_check_user_or_project_is_none(self, notify,
+                                                   mock_find, mock_action):
+        x_cluster = mock.Mock(id='CID',
+                              project='956033b6e9ac4d1999a2f504748b0f73')
+        mock_find.return_value = x_cluster
+        mock_action.return_value = 'ACTION_ID'
+
+        params = {'foo': 'bar'}
+        result = self.eng.cluster_check(self.ctx, 'CLUSTER', params)
+
+        self.assertIsNotNone(x_cluster.user)
         self.assertEqual({'action': 'ACTION_ID'}, result)
         mock_find.assert_called_once_with(self.ctx, 'CLUSTER')
         mock_action.assert_called_once_with(


### PR DESCRIPTION
This patch fixes cluster-check context in  health manage.

Bug-ES #9688
http://192.168.15.2/issues/9688

Signed-off-by: Yuanbin.Chen <cybing4@gmail.com>