### PR TITLE
Fix user, project, domain columns in sqlalchemy

### DIFF
--- a/senlin/db/sqlalchemy/migrate_repo/versions/007_placeholder.py
+++ b/senlin/db/sqlalchemy/migrate_repo/versions/007_placeholder.py
@@ -1,0 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+def upgrade(migrate_engine):
+    pass

--- a/senlin/db/sqlalchemy/migrate_repo/versions/008_placeholder.py
+++ b/senlin/db/sqlalchemy/migrate_repo/versions/008_placeholder.py
@@ -1,0 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+def upgrade(migrate_engine):
+    pass

--- a/senlin/db/sqlalchemy/migrate_repo/versions/009_placeholder.py
+++ b/senlin/db/sqlalchemy/migrate_repo/versions/009_placeholder.py
@@ -1,0 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+def upgrade(migrate_engine):
+    pass

--- a/senlin/db/sqlalchemy/migrate_repo/versions/010_user_project_length.py
+++ b/senlin/db/sqlalchemy/migrate_repo/versions/010_user_project_length.py
@@ -1,0 +1,26 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from sqlalchemy import MetaData, Table, String
+
+
+def upgrade(migrate_engine):
+    meta = MetaData()
+    meta.bind = migrate_engine
+
+    for table_name in ['profile', 'policy', 'cluster', 'node', 'receiver',
+                       'credential', 'action', 'event']:
+        table = Table(table_name, meta, autoload=True)
+        table.c.user.alter(type=String(64))
+        table.c.project.alter(type=String(64))
+        if table_name not in ['credential', 'event']:
+            table.c.domain.alter(type=String(64))


### PR DESCRIPTION
This patch fixes the 'user', 'project' and 'domain' columns in
sqlalchemy database. We have been using varchar(32) for these
fields, however, Keystone is modeling them as varchar(64) for
use with other backends, e.g. LDAP.

Closes-Bug: #1655207
Change-Id: I4432ac9838cdeed9344f2f43dd77d58479d2a69a
(cherry picked from commit cf1de30510a5b2de3b5a07b360c8d8d84bb031cf)

Bug-ES #9985
http://192.168.15.2/issues/9985