### PR TITLE
Fix node display error

### DIFF
--- a/senlin/policies/eayunlb_policy.py
+++ b/senlin/policies/eayunlb_policy.py
@@ -297,6 +297,8 @@ class LoadBalancingPolicy(base.Policy):
                 action.data['reason'] = _('Failed in removing deleted '
                                           'node(s) from lb pool.')
                 return
+            node.data.pop('lb_member')
+            node.store(action.context)
 
         return
 


### PR DESCRIPTION
This patch fix node del from cluster, node delete member from
loadbance, the node data display don't remove lb_member record.

Signed-off-by: Yuanbin.Chen <cybing4@gmail.com>