### PR TITLE
Fix cluster check change cluster suspend to active status

### DIFF
--- a/senlin/engine/service.py
+++ b/senlin/engine/service.py
@@ -1397,6 +1397,10 @@ class EngineService(service.Service):
         LOG.info(_LI("Checking Cluster '%(cluster)s'."),
                  {'cluster': identity})
         db_cluster = self.cluster_find(context, identity)
+        # cluster check don't able to check has exist suspend cluster
+        if db_cluster.status in [cluster_mod.Cluster.SUSPEND]:
+            raise exception.ForbiddenAction(type='cluster', id=identity,
+                                            status=db_cluster.status)
         if not context.user or not context.project:
             context.user = db_cluster.user
             context.project = db_cluster.project


### PR DESCRIPTION
This patch fix cluster check, if cluster suspend status,
the cluster-check don't finish cluster check operation.

Bug-ES #10616
http://192.168.15.2/issues/10616

Signed-off-by: Yuanbin.Chen <cybing4@gmail.com>