### PR TITLE
Fix node create always in init status

### DIFF
--- a/senlin/engine/actions/node_action.py
+++ b/senlin/engine/actions/node_action.py
@@ -67,6 +67,7 @@ class NodeAction(base.Action):
                 cluster, cluster.desired_capacity + 1, None, None, True)
 
             if result:
+                self.node.set_status(self.context, self.RES_ERROR, params={})
                 return self.RES_ERROR, result
             # Update cluster desired_capacity if node is already in db.
             cluster.desired_capacity += 1


### PR DESCRIPTION
This patch fix node create status, if node crate configure cluster,
the cluster has max_size, the node will be always init status.

Bug-ES #10623
http://192.168.15.2/issues/10623

Signed-off-by: Yuanbin.Chen <cybing4@gmail.com>