### PR TITLE
Fix senlin cluster load delete policy error

### DIFF
--- a/senlin/engine/actions/node_action.py
+++ b/senlin/engine/actions/node_action.py
@@ -194,7 +194,7 @@ class NodeAction(base.Action):
         """
         # Check the size constraint of parent cluster
         cluster = cm.Cluster.load(self.context, self.node.cluster_id)
-        new_capacity = cluster.desired_capacity - 1
+        new_capacity = cluster.desired_capacity
         result = scaleutils.check_size_params(cluster, new_capacity,
                                               None, None, True)
         if result:


### PR DESCRIPTION
This patch fix delete policy destroy_after_deletion
value False error

Bug-ES #10665
http://192.168.15.2/issues/10665

Signed-off-by: Yuanbin.Chen <cybing4@gmail.com>