### PR TITLE
Fix cluster_timeout don't load cluster configure timeout time.

### DIFF
--- a/senlin/engine/actions/cluster_action.py
+++ b/senlin/engine/actions/cluster_action.py
@@ -70,6 +70,7 @@ class ClusterAction(base.Action):
 
         try:
             self.cluster = cluster_mod.Cluster.load(self.context, self.target)
+            self.timeout = self.cluster.timeout
         except Exception:
             self.cluster = None
 


### PR DESCRIPTION
This patch fix cluster operation always use senlin config file
value "default_action_timeout"

Bug-ES #10609
http://192.168.15.2/issues/10609

Signed-off-by: Yuanbin.Chen <cybing4@gmail.com>