### PR TITLE
Fix cluster create configure max_size

### DIFF
--- a/senlin/api/openstack/v1/clusters.py
+++ b/senlin/api/openstack/v1/clusters.py
@@ -78,11 +78,14 @@ class ClusterData(object):
             raise exc.HTTPBadRequest(msg)
 
         if self.max_size is not None:
-            if (self.max_size >= 0 and self.max_size < self.desired_capacity)\
+            if (self.max_size > 0 and self.max_size < self.desired_capacity)\
                     or (self.max_size < -1):
                 msg = _("Cluster max_size, if specified, must be greater than "
                         "or equal to its desired capacity. Setting max_size "
                         "to -1 means no upper limit on cluster size.")
+                raise exc.HTTPBadRequest(msg)
+            elif self.max_size == 0:
+                msg = _("Cluster don't allow max_size equal to 0")
                 raise exc.HTTPBadRequest(msg)
 
     def validate_for_update(self):


### PR DESCRIPTION
This patch fix cluster create max_size value,
the max_size value don't allow eq 0.

Bug-ES #10607
http://192.168.15.2/issues/10607

Signed-off-by: Yuanbin.Chen <cybing4@gmail.com>