### PR TITLE
Change node recover operation parameter

### DIFF
--- a/senlin/profiles/os/nova/server.py
+++ b/senlin/profiles/os/nova/server.py
@@ -1144,6 +1144,9 @@ class ServerProfile(base.Profile):
             if operation == 'REBUILD' and server.id:
                 return self.do_rebuild(obj, server)
 
+        # When recover operation value 'REBUILD' the vm uuid not exist,
+        # Chanage operation value 'REBUILD' to 'RECREATE'.
+        options['operation'] = 'RECREATE'
         return super(ServerProfile, self).do_recover(obj, **options)
 
     def handle_reboot(self, obj, **options):


### PR DESCRIPTION
When node recover operation value 'REBUILD' the vm uuid not exist,
change recover operation value 'REBUILD' to 'RECREATE'

Signed-off-by: Yuanbin.Chen <cybing4@gmail.com>